### PR TITLE
Moved shutdown hook to reachable code block

### DIFF
--- a/word-count/src/main/java/com/github/simplesteph/udemy/kafka/streams/WordCountApp.java
+++ b/word-count/src/main/java/com/github/simplesteph/udemy/kafka/streams/WordCountApp.java
@@ -46,6 +46,9 @@ public class WordCountApp {
         KafkaStreams streams = new KafkaStreams(builder.build(), config);
         streams.start();
 
+        // shutdown hook to correctly close the streams application
+        Runtime.getRuntime().addShutdownHook(new Thread(streams::close));
+
         // Update:
         // print the topology every 10 seconds for learning purposes
         while(true){
@@ -57,7 +60,6 @@ public class WordCountApp {
             }
         }
 
-        // shutdown hook to correctly close the streams application
-        Runtime.getRuntime().addShutdownHook(new Thread(streams::close));
+
     }
 }


### PR DESCRIPTION
Verified the following:
`INFO stream-thread [wordcount-application-6c067f1f-af94-4320-9824-90564203ea7a-StreamThread-1] State transition from PENDING_SHUTDOWN to DEAD (org.apache.kafka.streams.processor.internals.StreamThread:346) `