### PR TITLE
Fixes assert parameter order

### DIFF
--- a/bank-balance-exactly-once/src/test/java/com/github/simplesteph/udemy/kafka/streams/BankTransactionsProducerTests.java
+++ b/bank-balance-exactly-once/src/test/java/com/github/simplesteph/udemy/kafka/streams/BankTransactionsProducerTests.java
@@ -18,12 +18,12 @@ public class BankTransactionsProducerTests {
         String key = record.key();
         String value = record.value();
 
-        assertEquals(key, "john");
+        assertEquals("john", key);
 
         ObjectMapper mapper = new ObjectMapper();
         try {
             JsonNode node = mapper.readTree(value);
-            assertEquals(node.get("name").asText(), "john");
+            assertEquals("john", node.get("name").asText());
             assertTrue("Amount should be less than 100", node.get("amount").asInt() < 100);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
This PR fixes the assert parameters. Currently, the expected value is used as the actual value. This reverses the order. 